### PR TITLE
added required positional argument (continues_batch_mode) to NetworkF…

### DIFF
--- a/NTLFlowLyzer/__main__.py
+++ b/NTLFlowLyzer/__main__.py
@@ -47,7 +47,7 @@ def main():
         output_file_name = file.split('/')[-1]
         config.pcap_file_address = file
         config.output_file_address = f"{batch_address_output}/{output_file_name}.csv"
-        network_flow_analyzer = NTLFlowLyzer(config, online_capturing)
+        network_flow_analyzer = NTLFlowLyzer(config, online_capturing, parsed_arguments.continues_batch_mode)
         network_flow_analyzer.run()
 
 


### PR DESCRIPTION
The current version gives us an error if we want to run in batch mode because the required positional argument is missing in __main__.py.

This issue is fixed in this pull request by passing the command line argument "continues_batch_mode" during the initialization of the NetFlowAnalyzer class.