### PR TITLE
Add optional UDP flow generation flag

### DIFF
--- a/NTLFlowLyzer/__main__.py
+++ b/NTLFlowLyzer/__main__.py
@@ -16,6 +16,8 @@ def args_parser() -> argparse.ArgumentParser:
     parser.add_argument('-cb', '--continues-batch-mode', action='store_true',
                         help='Continues batch mode. Analyze files in the given directory continuously.'
                             ' Default is False.')
+    parser.add_argument('--udp', action='store_true',
+                        help='Also create flows from UDP packets. By default only TCP flows are created.')
     return parser
 
 
@@ -30,9 +32,10 @@ def main():
     parsed_arguments = args_parser().parse_args()
     config_file_address = "./NTLFlowLyzer/config.json" if parsed_arguments.config_file is None else parsed_arguments.config_file
     online_capturing = parsed_arguments.online_capturing
+    include_udp = parsed_arguments.udp
     if not parsed_arguments.batch_mode:
         config = ConfigLoader(config_file_address)
-        network_flow_analyzer = NTLFlowLyzer(config, online_capturing, parsed_arguments.continues_batch_mode)
+        network_flow_analyzer = NTLFlowLyzer(config, online_capturing, parsed_arguments.continues_batch_mode, include_udp)
         network_flow_analyzer.run()
         return
 
@@ -47,7 +50,7 @@ def main():
         output_file_name = file.split('\\')[-1]
         config.pcap_file_address = file
         config.output_file_address = f"{batch_address_output}\\{output_file_name}.csv"
-        network_flow_analyzer = NTLFlowLyzer(config, online_capturing, parsed_arguments.continues_batch_mode)
+        network_flow_analyzer = NTLFlowLyzer(config, online_capturing, parsed_arguments.continues_batch_mode, include_udp)
         network_flow_analyzer.run()
 
 

--- a/NTLFlowLyzer/feature_extractor.py
+++ b/NTLFlowLyzer/feature_extractor.py
@@ -3,6 +3,7 @@
 from datetime import datetime
 from .features import *
 import warnings
+import math
 
 class FeatureExtractor(object):
     def __init__(self, floating_point_unit: str):
@@ -391,6 +392,17 @@ class FeatureExtractor(object):
                         continue
                     feature.set_floating_point_unit(self.floating_point_unit)
                     try:
+                        if flow.get_protocol() != "TCP":
+                            tcp_only_names = {
+                                "delta_start",
+                                "handshake_duration",
+                                "handshake_state",
+                                "fwd_init_win_bytes",
+                                "bwd_init_win_bytes",
+                            }
+                            if feature.__class__.__module__.endswith("flag_related") or feature.name in tcp_only_names:
+                                features_of_flow[feature.name] = math.nan
+                                continue
                         features_of_flow[feature.name] = feature.extract(flow)
                     except Exception as e:
                         print(f">>> Error occured in extracting the '{feature.name}' for '{flow}' flow.")

--- a/NTLFlowLyzer/network_flow_analyzer.py
+++ b/NTLFlowLyzer/network_flow_analyzer.py
@@ -15,9 +15,10 @@ from dpkt import ethernet
 
 
 class NTLFlowLyzer(object):
-    def __init__(self, config: ConfigLoader, online_capturing: bool, continues_batch_mode: bool):
+    def __init__(self, config: ConfigLoader, online_capturing: bool, continues_batch_mode: bool, include_udp: bool = False):
         self.__config = config
         self.__continues_batch_mode = continues_batch_mode
+        self.__include_udp = include_udp
         warnings.filterwarnings("ignore")
 
     def run(self):
@@ -67,7 +68,8 @@ class NTLFlowLyzer(object):
                         continues_pcap_prefix=self.__config.continues_pcap_prefix,
                         number_of_continues_files=self.__config.number_of_continues_files,
                         continues_batch_mode=self.__continues_batch_mode,
-                        base_number_continues_files=self.__config.base_number_continues_files)
+                        base_number_continues_files=self.__config.base_number_continues_files,
+                        include_udp=self.__include_udp)
                 writer_thread = Process(target=self.writer)
                 writer_thread.start()
                 with Pool(processes=number_of_extractor_threads) as pool:

--- a/NTLFlowLyzer/network_flow_capturer/network_flow_capturer.py
+++ b/NTLFlowLyzer/network_flow_capturer/network_flow_capturer.py
@@ -18,7 +18,7 @@ class NetworkFlowCapturer:
                 read_packets_count_value_log_info: int, vxlan_ip: str,
                 continues_batch_address: str, continues_pcap_prefix: str,
                 number_of_continues_files: int, continues_batch_mode: bool,
-                base_number_continues_files:int):
+                base_number_continues_files:int, include_udp: bool = False):
         self.__finished_flows = []
         self.__ongoing_flows = {}
         self.__max_flow_duration = max_flow_duration
@@ -32,6 +32,7 @@ class NetworkFlowCapturer:
         self.__number_of_continues_files = number_of_continues_files
         self.__continues_batch_mode = continues_batch_mode
         self.__base_number_continues_files = base_number_continues_files
+        self.__include_udp = include_udp
         self.flows_counter = 0
         self.tcp_packets = 0
         self.udp_packets = 0
@@ -185,7 +186,10 @@ class NetworkFlowCapturer:
                     continue
                 ip = eth.data
 
-                if not isinstance(ip.data, dpkt.tcp.TCP):
+                transport = ip.data
+                if not isinstance(transport, dpkt.tcp.TCP) and not (
+                    self.__include_udp and isinstance(transport, dpkt.udp.UDP)
+                ):
                     continue
 
                 if (socket.inet_ntoa(ip.src) == self.__vxlan_ip) or (socket.inet_ntoa(ip.dst) == self.__vxlan_ip):
@@ -194,27 +198,45 @@ class NetworkFlowCapturer:
                         (socket.inet_ntoa(ip.dst) == self.__vxlan_ip and socket.inet_ntoa(ip.src)[0:5] == "10.0.")):
                         continue
 
-                if not isinstance(ip.data, dpkt.tcp.TCP):
-                    continue
+                if isinstance(transport, dpkt.tcp.TCP):
+                    tcp_layer = transport
+                    network_protocol = 'TCP'
+                    src_port = tcp_layer.sport
+                    dst_port = tcp_layer.dport
+                    payload = tcp_layer.data
+                    header_size = len(tcp_layer) - len(payload)
 
-                tcp_layer = ip.data
-                network_protocol = 'TCP'
-                window_size = tcp_layer.win
-                tcp_flags = tcp_layer.flags
-                seq_number = tcp_layer.seq
-                ack_number = tcp_layer.ack
+                    window_size = tcp_layer.win
+                    tcp_flags = tcp_layer.flags
+                    seq_number = tcp_layer.seq
+                    ack_number = tcp_layer.ack
+                else:
+                    udp_layer = transport
+                    network_protocol = 'UDP'
+                    src_port = udp_layer.sport
+                    dst_port = udp_layer.dport
+                    payload = udp_layer.data
+                    header_size = len(udp_layer) - len(payload)
+
+                    # UDP has no TCP flags, sequence numbers, acknowledgements,
+                    # or advertised receive window. Keep the existing packet
+                    # schema stable and mark those packet fields as neutral.
+                    window_size = 0
+                    tcp_flags = 0
+                    seq_number = 0
+                    ack_number = 0
 
                 nlflyzer_packet = Packet(
                     src_ip=socket.inet_ntoa(ip.src), 
-                    src_port=tcp_layer.sport,
+                    src_port=src_port,
                     dst_ip=socket.inet_ntoa(ip.dst), 
-                    dst_port=tcp_layer.dport,
+                    dst_port=dst_port,
                     protocol=network_protocol, 
                     flags=tcp_flags,
                     timestamp=ts, 
                     length=len(new_buf),
-                    payloadbytes=len(tcp_layer.data), 
-                    header_size=len(ip.data) - len(tcp_layer.data),
+                    payloadbytes=len(payload),
+                    header_size=header_size,
                     window_size=window_size,
                     seq_number=seq_number,
                     ack_number=ack_number)

--- a/README.md
+++ b/README.md
@@ -6,10 +6,31 @@ As part of the Understanding Cybersecurity Series (UCS), NTLFlowLyzer is a Pytho
 
 NTLFlowLyzer generates bidirectional flows from the Network and Transportation Layers of network traffic, where the first packet determines the forward (source to destination) and backward (destination to source) directions, hence the statistical time-related features can be calculated separately in the forward and backward directions. Additional functionalities include selecting features from the list of existing features, adding new features, and controlling the duration of flow timeout. Moreover, TCP flows are terminated upon connection teardown (by FIN or RST packet), reaching the flow's maximum duration, or being inactive for a certain amount of time (timeout).
 
+## Optional UDP Flow Support
+
+By default, NTLFlowLyzer keeps its original behavior and creates flows from TCP
+packets only. To include UDP flows as well, pass `--udp`:
+
+```bash
+ntlflowlyzer --udp -c YOUR_CONFIG_FILE
+```
+
+User story: as a security researcher processing malware sandbox PCAPs, I need one
+NetFlow-style export that includes both TCP and UDP activity, because malware
+samples often use UDP for DNS, discovery, C2 bootstrap, or short-lived payload
+traffic. Dropping UDP packets at the flow-generation step leaves downstream
+labeling and analysis with an incomplete view of the sample behavior.
+
+The UDP support keeps the existing output schema. TCP-only packet fields and
+TCP-only derived features remain present; for UDP rows they are emitted as
+neutral packet values or `NaN` feature values. The behavior is documented in
+detail in [docs/udp-support.md](docs/udp-support.md).
+
 
 # Table of Contents
 
 - [NTLFlowLyzer](#ntlflowlyzer)
+- [Optional UDP Flow Support](#optional-udp-flow-support)
 - [Table of Contents](#table-of-contents)
 - [Installation](#installation)
 - [Execution](#execution)
@@ -177,6 +198,12 @@ ntlflowlyzer -c YOUR_CONFIG_FILE
 ```
 
 Replace `YOUR_CONFIG_FILE` with the path to your configuration file.
+
+To include UDP flows in addition to TCP flows, pass `--udp`:
+
+```bash
+ntlflowlyzer --udp -c YOUR_CONFIG_FILE
+```
 
 
 Moreover, this project has been successfully tested on Ubuntu 20.04, Ubuntu 22.04, Windows 10, and Windows 11. It should work on other versions of Ubuntu OS (or even Debian OS) as long as your system has the necessary Python3 packages (you can find the required packages listed in the `requirements.txt` file).

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,10 +6,31 @@ As part of the Understanding Cybersecurity Series (UCS), NTLFlowLyzer is a Pytho
 
 NTLFlowLyzer generates bidirectional flows from the Network and Transportation Layers of network traffic, where the first packet determines the forward (source to destination) and backward (destination to source) directions, hence the statistical time-related features can be calculated separately in the forward and backward directions. Additional functionalities include selecting features from the list of existing features, adding new features, and controlling the duration of flow timeout. Moreover, TCP flows are terminated upon connection teardown (by FIN or RST packet), reaching the flow's maximum duration, or being inactive for a certain amount of time (timeout).
 
+## Optional UDP Flow Support
+
+By default, NTLFlowLyzer keeps its original behavior and creates flows from TCP
+packets only. To include UDP flows as well, pass `--udp`:
+
+```bash
+ntlflowlyzer --udp -c YOUR_CONFIG_FILE
+```
+
+User story: as a security researcher processing malware sandbox PCAPs, I need one
+NetFlow-style export that includes both TCP and UDP activity, because malware
+samples often use UDP for DNS, discovery, C2 bootstrap, or short-lived payload
+traffic. Dropping UDP packets at the flow-generation step leaves downstream
+labeling and analysis with an incomplete view of the sample behavior.
+
+The UDP support keeps the existing output schema. TCP-only packet fields and
+TCP-only derived features remain present; for UDP rows they are emitted as
+neutral packet values or `NaN` feature values. The behavior is documented in
+detail in [udp-support.md](udp-support.md).
+
 
 # Table of Contents
 
 - [NTLFlowLyzer](#ntlflowlyzer)
+- [Optional UDP Flow Support](#optional-udp-flow-support)
 - [Table of Contents](#table-of-contents)
 - [Installation](#installation)
 - [Execution](#execution)
@@ -177,6 +198,12 @@ ntlflowlyzer -c YOUR_CONFIG_FILE
 ```
 
 Replace `YOUR_CONFIG_FILE` with the path to your configuration file.
+
+To include UDP flows in addition to TCP flows, pass `--udp`:
+
+```bash
+ntlflowlyzer --udp -c YOUR_CONFIG_FILE
+```
 
 
 Moreover, this project has been successfully tested on Ubuntu 20.04, Ubuntu 22.04, Windows 10, and Windows 11. It should work on other versions of Ubuntu OS (or even Debian OS) as long as your system has the necessary Python3 packages (you can find the required packages listed in the `requirements.txt` file).

--- a/docs/udp-support.md
+++ b/docs/udp-support.md
@@ -1,0 +1,146 @@
+# UDP Flow Support
+
+This patch adds optional UDP flow generation to NTLFlowLyzer through the existing
+`ntlflowlyzer` command.
+
+## User Story
+
+As a security researcher processing malware sandbox PCAPs, I need a flow export
+that includes both TCP and UDP traffic, so that downstream labeling, inventory
+building, and family-level analysis can see the complete network behavior of a
+sample.
+
+The upstream parser emits TCP flows by default. For malware analysis this can
+hide important behavior: UDP can carry DNS lookups, service discovery, C2
+bootstrap traffic, or short-lived application traffic that helps explain later
+connections.
+
+The desired behavior is not to redefine every TCP feature for UDP. The desired
+behavior is to keep the existing NTLFlowLyzer output shape usable while adding
+UDP rows only when explicitly requested.
+
+## Usage
+
+Default behavior remains TCP-only:
+
+```bash
+ntlflowlyzer -c YOUR_CONFIG_FILE
+```
+
+To emit UDP flows in addition to TCP flows:
+
+```bash
+ntlflowlyzer --udp -c YOUR_CONFIG_FILE
+```
+
+The flag also works in batch mode:
+
+```bash
+ntlflowlyzer --udp -b -c YOUR_CONFIG_FILE
+```
+
+## Goals
+
+- Keep TCP-only behavior as the default.
+- Add UDP flows only when `--udp` is passed.
+- Preserve the existing CSV columns as much as possible.
+- Avoid a separate package name or a separate console command.
+- Make non-applicable TCP-only UDP values explicit and reviewable.
+
+## Non-Goals
+
+- This patch does not add UDP-specific statistical features beyond what the
+  existing packet/flow model can already calculate.
+- This patch does not reinterpret TCP handshake, TCP flag, TCP window, sequence,
+  or acknowledgement features for UDP.
+- This patch does not add DNS, QUIC, DTLS, or application payload parsing.
+- This patch does not change TCP flow extraction when `--udp` is not used.
+
+## Implementation
+
+Files:
+
+- `NTLFlowLyzer/__main__.py`
+- `NTLFlowLyzer/network_flow_analyzer.py`
+- `NTLFlowLyzer/network_flow_capturer/network_flow_capturer.py`
+- `NTLFlowLyzer/feature_extractor.py`
+
+The CLI adds:
+
+```text
+--udp
+```
+
+The flag is passed from the CLI to `NTLFlowLyzer`, then to
+`NetworkFlowCapturer`.
+
+When `--udp` is not passed, the capturer keeps the upstream TCP-only packet
+filter.
+
+When `--udp` is passed, the capturer accepts:
+
+- `dpkt.tcp.TCP`
+- `dpkt.udp.UDP`
+
+For TCP packets, the existing fields are preserved:
+
+- source and destination ports
+- TCP flags
+- sequence number
+- acknowledgement number
+- TCP window size
+- TCP payload length
+- transport header length
+
+For UDP packets, the capturer creates a normal `Packet` object using:
+
+- UDP source port
+- UDP destination port
+- UDP payload length
+- UDP header length
+
+UDP has no TCP flags, sequence numbers, acknowledgements, or advertised receive
+window. Those packet fields are filled with neutral zero values to keep the
+existing schema stable:
+
+- `window_size = 0`
+- `tcp_flags = 0`
+- `seq_number = 0`
+- `ack_number = 0`
+
+## TCP-Only Features On UDP Rows
+
+Some derived features are meaningful only for TCP. For UDP flows, this patch
+emits `NaN` for those features instead of logging repeated extraction errors or
+fabricating numeric values.
+
+Currently treated as TCP-only:
+
+- all features from the `flag_related` feature module
+- `delta_start`
+- `handshake_duration`
+- `handshake_state`
+- `fwd_init_win_bytes`
+- `bwd_init_win_bytes`
+
+All non-TCP-specific features continue to be extracted normally for UDP flows.
+
+## Compatibility Notes
+
+- `ntlflowlyzer -c YOUR_CONFIG_FILE` remains TCP-only.
+- `ntlflowlyzer --udp -c YOUR_CONFIG_FILE` emits TCP and UDP flows.
+- TCP behavior is intended to stay unchanged.
+- Downstream consumers should treat `NaN` TCP-only feature values on UDP rows as
+  "not applicable".
+- Existing CSV columns remain present so downstream tooling does not need a
+  separate UDP schema branch.
+
+## Review Notes
+
+Suggested review focus:
+
+- Confirm TCP code paths still use the same packet fields as upstream.
+- Confirm UDP is gated behind `--udp`.
+- Confirm UDP packet fields use UDP ports, payload length, and header length.
+- Confirm TCP-only features are the only features forced to `NaN` for UDP.
+- Confirm the default command remains TCP-only.


### PR DESCRIPTION
User story: as a security researcher processing malware sandbox PCAPs, I need one NetFlow-style export that can include both TCP and UDP activity, because malware samples can use UDP for DNS, discovery, C2 bootstrap, or short-lived payload traffic. Dropping UDP packets at flow generation leaves downstream labeling and analysis with an incomplete view of sample behavior.

This patch keeps upstream behavior as the default. Running `ntlflowlyzer -c CONFIG` remains TCP-only. Passing `--udp` enables UDP flow creation in addition to TCP flow creation.

The CLI passes the flag through NTLFlowLyzer into NetworkFlowCapturer. The capturer accepts UDP packets only when the flag is set. TCP packet handling keeps the existing source/destination ports, flags, sequence numbers, acknowledgements, window size, payload length, and header length.

For UDP packets, the capturer uses real UDP ports, payload length, and UDP header length. TCP-only packet fields are retained for schema compatibility and filled with neutral zero values.

The feature extractor writes NaN for TCP-only derived features on UDP rows instead of logging extraction errors or fabricating values. Non-TCP-specific features continue to be extracted normally.

README.md, docs/index.md, and docs/udp-support.md document the usage, goals, non-goals, compatibility behavior, and review focus for the `--udp` feature.

Validated on a large Windows malware PCAP corpus; further testing and review are welcome.